### PR TITLE
Add support for networkmanager

### DIFF
--- a/resources/networkmanager-connectpeer.go
+++ b/resources/networkmanager-connectpeer.go
@@ -1,0 +1,59 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/networkmanager"
+)
+
+type NetworkManagerConnectPeer struct {
+	svc *networkmanager.NetworkManager
+	ID  *string
+}
+
+func init() {
+	register("NetworkManagerConnectPeer", ListNetworkManagerConnectPeers)
+}
+
+func ListNetworkManagerConnectPeers(sess *session.Session) ([]Resource, error) {
+	svc := networkmanager.New(sess)
+	resources := []Resource{}
+
+	input := &networkmanager.ListConnectPeersInput{
+		MaxResults: aws.Int64(100),
+	}
+
+	for {
+		output, err := svc.ListConnectPeers(input)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, connectPeer := range output.ConnectPeers {
+			resources = append(resources, &NetworkManagerConnectPeer{
+				svc: svc,
+				ID:  connectPeer.ConnectPeerId,
+			})
+		}
+
+		if output.NextToken == nil {
+			break
+		}
+
+		input.NextToken = output.NextToken
+	}
+
+	return resources, nil
+}
+
+func (f *NetworkManagerConnectPeer) Remove() error {
+	_, err := f.svc.DeleteConnectPeer(&networkmanager.DeleteConnectPeerInput{
+		ConnectPeerId: f.ID,
+	})
+
+	return err
+}
+
+func (f *NetworkManagerConnectPeer) String() string {
+	return *f.ID
+}

--- a/resources/networkmanager-corenetwork.go
+++ b/resources/networkmanager-corenetwork.go
@@ -1,0 +1,59 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/networkmanager"
+)
+
+type NetworkManagerCoreNetwork struct {
+	svc *networkmanager.NetworkManager
+	ID  *string
+}
+
+func init() {
+	register("NetworkManagerCoreNetwork", ListNetworkManagerCoreNetworks)
+}
+
+func ListNetworkManagerCoreNetworks(sess *session.Session) ([]Resource, error) {
+	svc := networkmanager.New(sess)
+	resources := []Resource{}
+
+	input := &networkmanager.ListCoreNetworksInput{
+		MaxResults: aws.Int64(100),
+	}
+
+	for {
+		output, err := svc.ListCoreNetworks(input)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, coreNetwork := range output.CoreNetworks {
+			resources = append(resources, &NetworkManagerCoreNetwork{
+				svc: svc,
+				ID:  coreNetwork.CoreNetworkId,
+			})
+		}
+
+		if output.NextToken == nil {
+			break
+		}
+
+		input.NextToken = output.NextToken
+	}
+
+	return resources, nil
+}
+
+func (f *NetworkManagerCoreNetwork) Remove() error {
+	_, err := f.svc.DeleteCoreNetwork(&networkmanager.DeleteCoreNetworkInput{
+		CoreNetworkId: f.ID,
+	})
+
+	return err
+}
+
+func (f *NetworkManagerCoreNetwork) String() string {
+	return *f.ID
+}

--- a/resources/networkmanager-globalnetwork.go
+++ b/resources/networkmanager-globalnetwork.go
@@ -1,0 +1,59 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/networkmanager"
+)
+
+type NetworkManagerGlobalNetwork struct {
+	svc *networkmanager.NetworkManager
+	ID  *string
+}
+
+func init() {
+	register("NetworkManagerGlobalNetwork", ListNetworkManagerGlobalNetworks)
+}
+
+func ListNetworkManagerGlobalNetworks(sess *session.Session) ([]Resource, error) {
+	svc := networkmanager.New(sess)
+	resources := []Resource{}
+
+	input := &networkmanager.DescribeGlobalNetworksInput{
+		MaxResults: aws.Int64(100),
+	}
+
+	for {
+		output, err := svc.DescribeGlobalNetworks(input)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, globalNetwork := range output.GlobalNetworks {
+			resources = append(resources, &NetworkManagerGlobalNetwork{
+				svc: svc,
+				ID:  globalNetwork.GlobalNetworkId,
+			})
+		}
+
+		if output.NextToken == nil {
+			break
+		}
+
+		input.NextToken = output.NextToken
+	}
+
+	return resources, nil
+}
+
+func (f *NetworkManagerGlobalNetwork) Remove() error {
+	_, err := f.svc.DeleteGlobalNetwork(&networkmanager.DeleteGlobalNetworkInput{
+		GlobalNetworkId: f.ID,
+	})
+
+	return err
+}
+
+func (f *NetworkManagerGlobalNetwork) String() string {
+	return *f.ID
+}

--- a/resources/networkmanager-networkattachment.go
+++ b/resources/networkmanager-networkattachment.go
@@ -1,0 +1,59 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/networkmanager"
+)
+
+type NetworkManagerNetworkAttachment struct {
+	svc *networkmanager.NetworkManager
+	ID  *string
+}
+
+func init() {
+	register("NetworkManagerNetworkAttachment", ListNetworkManagerNetworkAttachments)
+}
+
+func ListNetworkManagerNetworkAttachments(sess *session.Session) ([]Resource, error) {
+	svc := networkmanager.New(sess)
+	resources := []Resource{}
+
+	input := &networkmanager.ListAttachmentsInput{
+		MaxResults: aws.Int64(100),
+	}
+
+	for {
+		output, err := svc.ListAttachments(input)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, NetworkAttachment := range output.Attachments {
+			resources = append(resources, &NetworkManagerNetworkAttachment{
+				svc: svc,
+				ID:  NetworkAttachment.AttachmentId,
+			})
+		}
+
+		if output.NextToken == nil {
+			break
+		}
+
+		input.NextToken = output.NextToken
+	}
+
+	return resources, nil
+}
+
+func (f *NetworkManagerNetworkAttachment) Remove() error {
+	_, err := f.svc.DeleteAttachment(&networkmanager.DeleteAttachmentInput{
+		AttachmentId: f.ID,
+	})
+
+	return err
+}
+
+func (f *NetworkManagerNetworkAttachment) String() string {
+	return *f.ID
+}


### PR DESCRIPTION
I thought our aws-nuke fork already had support for networkmanager resources, but apparently it does not (probably looked at the other aws-nuke... 😅). This PR backports that functionality to our fork.