### PR TITLE
feat(cloudformation-stack): add ForceDeleteStack setting

### DIFF
--- a/docs/resources/cloud-formation-stack.md
+++ b/docs/resources/cloud-formation-stack.md
@@ -38,6 +38,7 @@ The string value is always what is used in the output of the log format when a r
 - `DisableDeletionProtection`
 - `CreateRoleToDeleteStack`
 - `UseCurrentRoleToDeleteStack`
+- `ForceDeleteStack`
 
 
 ### DisableDeletionProtection
@@ -91,5 +92,24 @@ CloudFormationStack:
     If the assumed role has an IAM path prefix (e.g. `arn:aws:iam::123456789012:role/my-path/MyRole`), the STS
     assumed-role ARN omits the path component. The reconstructed role ARN will not include the path, which may
     result in an incorrect ARN. This is uncommon in typical CDK or CloudFormation use cases.
+
+
+### ForceDeleteStack
+
+When enabled, aws-nuke passes `DeletionMode=FORCE_DELETE_STACK` to the `DeleteStack` API. CloudFormation drops the
+stack record even when individual resources fail to delete, leaving any failed resources orphaned in the account
+instead of leaving the stack in `DELETE_FAILED`.
+
+This is useful when a stack is stuck in `DELETE_FAILED` and the goal is to release the stack record regardless of
+whether all its resources can be deleted.
+
+```yaml
+CloudFormationStack:
+  ForceDeleteStack: "true"
+```
+
+!!! warning "Orphaned Resources"
+    Resources that fail to delete remain in the account after the stack is gone. Filters scoped to the stack
+    (such as filters on `CloudFormationStack` by stack name) no longer apply to those resources.
 
 

--- a/resources/cloudformation-stack.go
+++ b/resources/cloudformation-stack.go
@@ -43,6 +43,7 @@ func init() {
 			"DisableDeletionProtection",
 			"CreateRoleToDeleteStack",
 			"UseCurrentRoleToDeleteStack",
+			"ForceDeleteStack",
 		},
 	})
 }
@@ -234,6 +235,19 @@ func (r *CloudFormationStack) resolveCallerRoleARN() *string {
 	return r.callerRoleARN
 }
 
+// applyForceDelete sets DeletionMode=FORCE_DELETE_STACK on a DeleteStackInput
+// if ForceDeleteStack is enabled. CloudFormation drops the stack record and
+// orphans any resources it cannot delete, instead of leaving the stack in
+// DELETE_FAILED. Useful for tear-down scenarios where the goal is to release
+// the stack, not preserve its resources.
+func (r *CloudFormationStack) applyForceDelete(input *cloudformation.DeleteStackInput) {
+	if !r.settings.GetBool("ForceDeleteStack") {
+		return
+	}
+	r.logger.Infof("CloudFormationStack stackName=%s ForceDeleteStack: using DeletionMode=FORCE_DELETE_STACK", *r.Name)
+	input.DeletionMode = aws.String(cloudformation.DeletionModeForceDeleteStack)
+}
+
 // applyRoleOverride sets the RoleARN on a DeleteStackInput if UseCurrentRoleToDeleteStack is enabled.
 func (r *CloudFormationStack) applyRoleOverride(input *cloudformation.DeleteStackInput) {
 	if !r.settings.GetBool("UseCurrentRoleToDeleteStack") {
@@ -379,6 +393,7 @@ func (r *CloudFormationStack) doRemove() error { //nolint:gocyclo
 			RetainResources: retain,
 		}
 		r.applyRoleOverride(deleteInput)
+		r.applyForceDelete(deleteInput)
 
 		if _, err = r.svc.DeleteStack(deleteInput); err != nil {
 			return err
@@ -396,6 +411,7 @@ func (r *CloudFormationStack) doRemove() error { //nolint:gocyclo
 			StackName: r.Name,
 		}
 		r.applyRoleOverride(deleteInput)
+		r.applyForceDelete(deleteInput)
 
 		if _, err := r.svc.DeleteStack(deleteInput); err != nil {
 			return err


### PR DESCRIPTION
Fork-side review for the upstream PR ekristen/aws-nuke#985.

Adds a new opt-in `ForceDeleteStack` setting that passes `DeletionMode=FORCE_DELETE_STACK` to `DeleteStack`. CloudFormation drops the stack record even when resources fail to delete, leaving orphans rather than the stack stuck in DELETE_FAILED.

Useful for tear-down scenarios where the goal is to release the stack, not preserve its resources — sandbox/CI account cleanup is the common case.

Default behavior is unchanged. Existing `CreateRoleToDeleteStack` and `UseCurrentRoleToDeleteStack` flows are untouched.